### PR TITLE
add feature flag service to proto file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@ release.
   demo](https://github.com/GoogleCloudPlatform/microservices-demo) with express
   knowledge of the owners. The pre-existing copyrights will remain. Any
   future significant modifications will be credited to OpenTelemetry Authors.
+* Added feature flag service protos
+  ([#26](https://github.com/open-telemetry/opentelemetry-demo-webstore/pull/26))

--- a/pb/demo.proto
+++ b/pb/demo.proto
@@ -14,6 +14,8 @@
 
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+
 package hipstershop;
 
 option go_package = "genproto/hipstershop";
@@ -260,3 +262,58 @@ message Ad {
     // short advertisement text to display.
     string text = 2;
 }
+
+// ------------Feature flag service------------------
+
+service FeatureFlagService {
+  rpc GetFlag(GetFlagRequest) returns (GetFlagResponse) {}
+  rpc CreateFlag(CreateFlagRequest) returns (CreateFlagResponse) {}
+  rpc UpdateFlag(UpdateFlagRequest) returns (UpdateFlagResponse) {}
+  rpc ListFlags(ListFlagsRequest) returns (ListFlagsResponse) {}
+  rpc DeleteFlag(DeleteFlagRequest) returns (DeleteFlagResponse) {}
+}
+
+message Flag {
+  string name = 1;
+  string description = 2;
+  bool enabled = 3;
+  google.protobuf.Timestamp created_at = 4;
+  google.protobuf.Timestamp updated_at = 5;
+}
+
+message GetFlagRequest {
+  string name = 1;
+}
+
+message GetFlagResponse {
+  Flag flag = 1;
+}
+
+message CreateFlagRequest {
+  string name = 1;
+  string description = 2;
+  bool enabled = 3;
+}
+
+message CreateFlagResponse {
+  Flag flag = 1;
+}
+
+message UpdateFlagRequest {
+  string name = 1;
+  bool enabled = 2;
+}
+
+message UpdateFlagResponse {}
+
+message ListFlagsRequest {}
+
+message ListFlagsResponse {
+  repated Flag flag = 1;
+}
+
+message DeleteFlagRequest {
+  string name = 1;
+}
+
+message DeleteFlagResponse {}


### PR DESCRIPTION
Protos for issue #28 

## Changes

This adds the feature flag service protos. I figured this was the best place to start with adding this service. 

I can open a design discussion issue like the check boxes below say but I thought this might be simply enough to just open a PR. I didn't include anything beyond a feature flag having a name and a bool, to keep it simple. I assume we don't want stuff like variants/experiments/etc, but could easily add them to this PR if they are.

---

For significant contributions please make sure you have completed the following items:

* [ ] Appropriate `CHANGELOG.md` updated for non-trivial changes
* [ ] Design discussion issue #
