### PR TITLE
remove explicit sampling until sampling strategy is defined

### DIFF
--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -68,7 +68,6 @@ func InitTracerProvider() *sdktrace.TracerProvider {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)

--- a/src/productcatalogservice/server.go
+++ b/src/productcatalogservice/server.go
@@ -83,7 +83,6 @@ func InitTracerProvider() *sdktrace.TracerProvider {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)

--- a/src/shippingservice/main.go
+++ b/src/shippingservice/main.go
@@ -65,7 +65,6 @@ func InitTracerProvider() *sdktrace.TracerProvider {
 		log.Fatal(err)
 	}
 	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
 	)
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
A sampling strategy hasn't been defined for our application yet. Several Go apps use explicit sampling but no where else. Removing the always on sampler until we have a strategy. 
