### PR TITLE
ruby: switch to `-slim` image

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ruby:3.1.2
+FROM ruby:3.1.2-slim
+
+RUN apt-get update -y && apt-get install -y build-essential
 
 COPY Gemfile* .
 RUN bundle install


### PR DESCRIPTION
## Changes

If I had invested, say, a mere modicum of effort into understanding what
needed to be done to use a `-slim` image in the first place, then we
would have included this in #109 from the start. However, I clearly did not. :facepalm:

This change switches us to the `-slim` image, and installs the one thing
we actually need to build `puma`: Debian's `build-essential` package.
