### PR TITLE
Delete `/pb/` directory's `README.md`

### DIFF
--- a/pb/README.md
+++ b/pb/README.md
@@ -1,3 +1,0 @@
-# Read Me
-
-This is a placeholder


### PR DESCRIPTION
No necessary and currently gets copied unnecessarily in the `Dockerfile`s - that could be avoided by making the copy commands only copy all `*.pb` but I'm not sure how much explaining is needed for this file. Each service should explain in their own README files what types of requests they can receive and what their responses will look like and any outgoing requests too?