### PR TITLE
Remove `/pb/READMD.md` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ classDef php fill:#4f5d95,color:white;
 
 _To view a graph of the desired state of this application [click here](./docs/v1Graph.md)_
 
-Find **Protocol Buffers Descriptions** at the [`./pb` directory](./pb/README.md).
+Find the **Protocol Buffer Definitions** in the `/pb/` directory.
 
 | Service                                              | Language      | Description                                                                                                                       |
 | ---------------------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |

--- a/pb/README.md
+++ b/pb/README.md
@@ -1,3 +1,0 @@
-# Read Me
-
-This is a placeholder


### PR DESCRIPTION
File not necessary and currently gets copied unnecessarily in the `Dockerfile`s - that could be avoided by making the copy commands only copy all `*.pb` but I'm not sure how much explaining is needed for this file that can't be done in the self-contained comments. Each service should explain in their own `README.md` files what types of requests they can receive and what their responses will look like and any outgoing requests too?

- Replaces https://github.com/open-telemetry/opentelemetry-demo-webstore/pull/131 (see [discussion started to avoid these kind of PR open and closes](https://discord.com/channels/@me/287436405045460993/986372501145808956))