### PR TITLE
[frontend] - remove erroneous parentheses in readme

### DIFF
--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -20,7 +20,7 @@ else.
   Libraries](https://opentelemetry.io/docs/concepts/instrumenting-library/):
   :100:
 - [Manual Span
-  Creation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#manual-instrumentation)):
+  Creation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#manual-instrumentation):
   :red_circle:
 - [Span Data
   Enrichment](https://opentelemetry.io/docs/instrumentation/net/manual/#add-tags-to-an-activity):
@@ -41,7 +41,7 @@ else.
   Libraries](https://opentelemetry.io/docs/concepts/instrumenting-library/):
   :red_circle:
 - [Manual Metric
-  Creation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#manual-instrumentation)):
+  Creation](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#manual-instrumentation):
   :red_circle:
 - [Collector Agent Metric
   Transformation](https://opentelemetry.io/docs/collector/deployment/#agent)::red_circle:


### PR DESCRIPTION
Fixes #.

Removes 2 erroneous parentheses in the readme

