### PR TITLE
Add manual instrumentation to emailservice

### DIFF
--- a/src/emailservice/email_server.rb
+++ b/src/emailservice/email_server.rb
@@ -12,11 +12,40 @@ end
 
 post "/send_order_confirmation" do
   data = JSON.parse(request.body.read, object_class: OpenStruct)
-  Pony.mail(
-    to:       data.email,
-    from:     "noreply@example.com",
-    subject:  "Your confirmation email",
-    body:     erb(:confirmation, locals: { order: data.order }),
-    via:      :logger
-  )
+
+  # get the current auto-instrumented span
+  current_span = OpenTelemetry::Trace.current_span
+  current_span.add_attributes({
+    "app.email.order_id" => data.order.order_id,
+    "app.email.shipping_tracking_id" => data.order.shipping_tracking_id,
+    "app.email.shipping_cost.currency" => data.order.shipping_cost.currency_code,
+    "app.email.shipping_cost" => data.order.shipping_cost.units.to_s + "." + 
+      data.order.shipping_cost.nanos.to_s
+  })
+
+  send_email(data)
+
+  rescue Exception => e
+    # record exception in span (will create a span event)
+    current_span.record_exception(e)
+    raise e
+end
+
+def send_email(data)
+  # create and start a manual span
+  tracer = OpenTelemetry.tracer_provider.tracer('')
+  tracer.in_span("send_email") do |span|
+    Pony.mail(
+      to:       data.email,
+      from:     "noreply@example.com",
+      subject:  "Your confirmation email",
+      body:     erb(:confirmation, locals: { order: data.order }),
+      via:      :logger
+    )
+    span.set_attribute("app.email.sent", true)
+  end
+  # manually created spans need to be ended
+  # in Ruby, the method `in_span` ends it automatically
+  # check out the OpenTelemetry Ruby docs at: 
+  # https://opentelemetry.io/docs/instrumentation/ruby/manual/#creating-new-spans 
 end


### PR DESCRIPTION
Towards #55 .

- [x] Services extend automatic instrumentation.
  - [x] New attributes/events attached to existing spans.
  - [x] New spans are being created from existing spans.

## Changes

Adds attributes to auto instrumented spans, and creates a new span with attributes.
If sending the email fails (what doesn't happen at the moment), `span.recordException()` is called from the auto-instrumented span, which ultimately creates a Span event.
