### PR TITLE
Fixing an emailservice build problem.

### DIFF
--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -16,7 +16,7 @@ FROM ruby:3.1.2-slim
 
 RUN apt-get update -y && apt-get install -y build-essential
 
-COPY Gemfile* .
+COPY Gemfile* ./
 RUN bundle install
 
 WORKDIR /email_server

--- a/src/emailservice/Dockerfile
+++ b/src/emailservice/Dockerfile
@@ -17,6 +17,7 @@ FROM ruby:3.1.2-slim
 RUN apt-get update -y && apt-get install -y build-essential
 
 COPY Gemfile* ./
+
 RUN bundle install
 
 WORKDIR /email_server


### PR DESCRIPTION
Fixing an emailservice build problem.

The build is currently failing when running
`docker-compose up`

Problem:
`Step 3/8 : COPY Gemfile* .
When using COPY with more than one source file, the destination must be a directory and end with a /
ERROR: Service 'emailservice' failed to build : Build failed`

## Changes

Dockerfile updated to fix the build. 
