### PR TITLE
Add list of all manual attributes

### DIFF
--- a/docs/manual_span_attributes.md
+++ b/docs/manual_span_attributes.md
@@ -11,7 +11,9 @@ This document contains the list of manual Span Attributes used throughout the de
 
 ## CartService
 
-* None yet
+* `app.product.id`
+* `app.product.quantity`
+* `app.user.id`
 
 ## CheckoutService
 

--- a/docs/manual_span_attributes.md
+++ b/docs/manual_span_attributes.md
@@ -8,11 +8,11 @@ This document contains the list of manual Span Attributes used throughout the de
 * `app.ads.contextKeys`
 * `app.ads.contextKeys.count`
 * `app.ads.count`
-  
+
 ## CartService
 
 * None yet
-  
+
 ## CheckoutService
 
 * `app.cart.items.count`

--- a/docs/manual_span_attributes.md
+++ b/docs/manual_span_attributes.md
@@ -1,0 +1,82 @@
+# List of manual span attributes
+
+This document contains the list of manual Span Attributes used throughout the demo-webstore:
+
+## AdService
+
+* `app.ads.category`
+* `app.ads.contextKeys`
+* `app.ads.contextKeys.count`
+* `app.ads.count`
+  
+## CartService
+
+* None yet
+  
+## CheckoutService
+
+* `app.cart.items.count`
+* `app.order.id`
+* `app.order.shipping.cost`
+* `app.order.total.cost`
+* `app.order.tracking.id`
+* `app.order.items.count`
+* `app.user.currency`
+* `app.user.id`
+
+## CurrencyService
+
+* None yet
+
+## EmailService
+
+* `app.email.sent`
+* `app.order.id`
+* `app.shipping.cost.currency`
+* `app.shipping.cost.total`
+* `app.shipping.tracking.id`
+
+## FeatureFlagService
+
+* None yet
+
+## Frontend
+
+* `app.cart.size`
+* `app.cart.items.count`
+* `app.cart.shipping.cost`
+* `app.cart.total.price`
+* `app.currency`
+* `app.currency.new`
+* `app.order.total`
+* `app.product.id`
+* `app.product.quantity`
+* `app.products.count`
+* `app.request.id`
+* `app.session.id`
+* `app.user.id`
+
+## LoadGenerator
+
+* None yet
+
+## PaymentService
+
+* `app.payment.cost`
+* `app.payment.currency`
+
+## ProductCatalogService
+
+* `app.product.id`
+* `app.product.name`
+* `app.products.count`
+
+## RecommendationService
+
+* `app.filtered_products.count`
+* `app.products.count`
+* `app.products_recommended.count`
+
+## ShippingService
+
+* None yet


### PR DESCRIPTION
With all the services being instrumented manually, it would be great if we could keep the span attributes documented.
I've went through all services and the opened PRs to create the initial  file.
From this, we can keep it updated whenever new PRs arrive, and we can follow a naming convention across all services.
