### PR TITLE
featureflagservice: use ipv4 address for http endpoint

### DIFF
--- a/src/featureflagservice/config/runtime.exs
+++ b/src/featureflagservice/config/runtime.exs
@@ -56,11 +56,7 @@ if config_env() == :prod do
   config :featureflagservice, FeatureflagserviceWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
     http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
-      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      ip: {0, 0, 0, 0},
       port: port
     ],
     secret_key_base: secret_key_base


### PR DESCRIPTION
Fixes FeatureFlag Service not booting in environments where ipv6 is not available.

# Changes

The IP the HTTP service listens on is changed from an ipv6 to ipv4 address.