### PR TITLE
Add Simple kubernetes setup to test 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,81 @@ build-docker-images:
 .PHONY: push-docker-images
 push-docker-images:
 	docker compose -f docker-compose.yml push
+
+
+.PHONY: k8s_local_apply_db
+k8s_local_apply_db:
+	kubectl apply -f k8s_local/redis.yaml
+	kubectl apply -f k8s_local/postgres.yaml
+	kubectl apply -f k8s_local/jaeger.yaml
+	kubectl apply -f k8s_local/prometheus.yaml
+	kubectl apply -f k8s_local/grafana.yaml
+	kubectl apply -f k8s_local/otel-agent-daemonset.yaml
+
+.PHONY: k8s_local_clean_db
+k8s_local_clean_db:
+	kubectl delete deployment redis
+	kubectl delete deployment postgres
+	kubectl delete deployment jaeger
+	kubectl delete deployment prometheus
+	kubectl delete deployment grafana
+	kubectl delete daemonset otel-agent
+	kubectl delete configmaps otel-agent-config
+	kubectl delete configmaps prometheus-config
+	kubectl delete configmaps grafana-config
+	kubectl delete configmaps grafana-provisioning
+	kubectl delete svc redis
+	kubectl delete svc postgres
+	kubectl delete svc jaeger
+	kubectl delete svc prometheus
+	kubectl delete svc grafana
+	kubectl delete svc otel-agent
+
+
+.PHONY: k8s_local_apply_services
+k8s_local_apply_services:
+	kubectl apply -f k8s_local/adservice.yaml
+	kubectl apply -f k8s_local/cartservice.yaml
+	kubectl apply -f k8s_local/checkoutservice.yaml
+	kubectl apply -f k8s_local/currencyservice.yaml
+	kubectl apply -f k8s_local/emailservice.yaml
+	kubectl apply -f k8s_local/featureflagservice.yaml
+	kubectl apply -f k8s_local/frontend.yaml
+	kubectl apply -f k8s_local/paymentservice.yaml
+	kubectl apply -f k8s_local/productcatalogservice.yaml
+	kubectl apply -f k8s_local/recommendationservice.yaml
+	kubectl apply -f k8s_local/shippingservice.yaml
+	kubectl apply -f k8s_local/loadgenerator.yaml
+
+.PHONY: k8s_local_clean_services
+k8s_local_clean_services:
+	kubectl delete deployment loadgenerator
+	kubectl delete deployment adservice
+	kubectl delete deployment cartservice
+	kubectl delete deployment checkoutservice
+	kubectl delete deployment currencyservice
+	kubectl delete deployment emailservice
+	kubectl delete deployment featureflagservice
+	kubectl delete deployment frontend
+	kubectl delete deployment paymentservice
+	kubectl delete deployment productcatalogservice
+	kubectl delete deployment recommendationservice
+	kubectl delete deployment shippingservice
+	kubectl delete svc adservice
+	kubectl delete svc cartservice
+	kubectl delete svc checkoutservice
+	kubectl delete svc currencyservice
+	kubectl delete svc emailservice
+	kubectl delete svc featureflagservice
+	kubectl delete svc frontend
+	kubectl delete svc paymentservice
+	kubectl delete svc productcatalogservice
+	kubectl delete svc recommendationservice
+	kubectl delete svc shippingservice
+
+
+.PHONY: k8s_local_apply
+k8s_local_apply: k8s_local_apply_db k8s_local_apply_services
+
+.PHONY: k8s_local_clean
+k8s_local_clean: k8s_local_clean_services k8s_local_clean_db

--- a/README.md
+++ b/README.md
@@ -223,6 +223,27 @@ Find the **Protocol Buffer Definitions** in the `/pb/` directory.
 | [featureflagservice](./src/featureflagservice/README.md)         | Erlang/Elixir | CRUD feature flag service to demonstrate various scenarios like fault injection & how to emit telemetry from a feature flag reliant service.                                             |
 | [loadgenerator](./src/loadgenerator/README.md)                 | Python/Locust | Continuously sends requests imitating realistic user shopping flows to the frontend.                                              |
 
+## Running on Kubernetes
+To Run the demo on kubernetes cluseter locally like minikube or docker kubernetes , we can apply the config present in `k8s_local` directory . Please be aware that this will deploy the application to the context kubectl is set to. 
+
+```
+make k8s_local_apply
+```
+We can port-forward to view ui, prometheus , jaeger & grafana . We can do port-forward to the services using the script `k8s_local/port_forward.sh`. Once the port-forward is successful we can view 
+
+- Webstore: <http://localhost:8080/>
+
+- Jaeger: <http://localhost:16686/>
+
+- Prometheus: <http://localhost:9090/>
+
+- Grafana: <http://localhost:3000/>
+
+To clean up the setup from kubernetes cluster run the command (please make sure you are using right kubernetes context ) 
+```
+make k8s_local_clean
+```
+
 ## Features
 
 - **[Kubernetes](https://kubernetes.io)**: the app is designed to run on

--- a/k8s_local/adservice.yaml
+++ b/k8s_local/adservice.yaml
@@ -1,0 +1,78 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adservice
+  labels:
+    app: adservice
+    component: otel-demo-adservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: adservice
+      component: otel-demo-adservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: adservice
+        app: adservice
+        component: otel-demo-adservice
+    spec:
+      containers:
+      - name: adservice
+        image:  otel/demo:v0.2.0-alpha-adservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=adservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: AD_SERVICE_PORT
+          value: "9555"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: adservice
+  labels:
+    app: adservice
+    component: otel-demo-adservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 9555
+      protocol: TCP
+      name: http
+  selector:
+    app: adservice
+    component: otel-demo-adservice
+---

--- a/k8s_local/adservice.yaml
+++ b/k8s_local/adservice.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/cartservice.yaml
+++ b/k8s_local/cartservice.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/cartservice.yaml
+++ b/k8s_local/cartservice.yaml
@@ -1,0 +1,83 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cartservice
+  labels:
+    app: cartservice
+    component: otel-demo-cartservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cartservice
+      component: otel-demo-cartservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: cartservice
+        app: cartservice
+        component: otel-demo-cartservice
+    spec:
+      containers:
+      - name: cartservice
+        image:  otel/demo:v0.2.0-alpha-cartservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=cartservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: CART_SERVICE_PORT
+          value: "7070"
+        - name: ASPNETCORE_URLS
+          value: "http://*:$(CART_SERVICE_PORT)"
+        - name: REDIS_ADDR
+          value: "redis"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cartservice
+  labels:
+    app: cartservice
+    component: otel-demo-cartservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 7070
+      protocol: TCP
+      name: http
+  selector:
+    app: cartservice
+    component: otel-demo-cartservice
+---
+

--- a/k8s_local/checkoutservice.yaml
+++ b/k8s_local/checkoutservice.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/checkoutservice.yaml
+++ b/k8s_local/checkoutservice.yaml
@@ -1,0 +1,105 @@
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checkoutservice
+  labels:
+    app: checkoutservice
+    component: otel-demo-checkoutservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: checkoutservice
+      component: otel-demo-checkoutservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: checkoutservice
+        app: checkoutservice
+        component: otel-demo-checkoutservice
+    spec:
+      containers:
+      - name: checkoutservice
+        image:  otel/demo:v0.2.0-alpha-checkoutservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=checkoutservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: CHECKOUT_SERVICE_PORT
+          value: "5050"
+        - name: CART_SERVICE_PORT
+          value: "7070"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:$(CART_SERVICE_PORT)"
+        - name: CURRENCY_SERVICE_PORT
+          value: "7000"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:$(CURRENCY_SERVICE_PORT)"
+        - name: EMAIL_SERVICE_PORT
+          value: "8080"
+        - name: EMAIL_SERVICE_ADDR
+          value: "http://emailservice:$(EMAIL_SERVICE_PORT)"
+        - name: PAYMENT_SERVICE_PORT
+          value: "50051"
+        - name: PAYMENT_SERVICE_ADDR
+          value: "paymentservice:$(PAYMENT_SERVICE_PORT)"
+        - name: PRODUCT_CATALOG_SERVICE_PORT
+          value: "3550"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:$(PRODUCT_CATALOG_SERVICE_PORT)"
+        - name: SHIPPING_SERVICE_PORT
+          value: "50051"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:$(SHIPPING_SERVICE_PORT)"
+
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: checkoutservice
+  labels:
+    app: checkoutservice
+    component: otel-demo-checkoutservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 5050
+      protocol: TCP
+      name: http
+  selector:
+    app: checkoutservice
+    component: otel-demo-checkoutservice
+---

--- a/k8s_local/currencyservice.yaml
+++ b/k8s_local/currencyservice.yaml
@@ -1,0 +1,79 @@
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: currencyservice
+  labels:
+    app: currencyservice
+    component: otel-demo-currencyservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: currencyservice
+      component: otel-demo-currencyservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: currencyservice
+        app: currencyservice
+        component: otel-demo-currencyservice
+    spec:
+      containers:
+      - name: currencyservice
+        image:  otel/demo:v0.2.0-alpha-currencyservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=currencyservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: PORT
+          value: "7000"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: currencyservice
+  labels:
+    app: currencyservice
+    component: otel-demo-currencyservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 7000
+      protocol: TCP
+      name: http
+  selector:
+    app: currencyservice
+    component: otel-demo-currencyservice
+---

--- a/k8s_local/currencyservice.yaml
+++ b/k8s_local/currencyservice.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/emailservice.yaml
+++ b/k8s_local/emailservice.yaml
@@ -27,10 +27,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/emailservice.yaml
+++ b/k8s_local/emailservice.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: emailservice
+  labels:
+    app: emailservice
+    component: otel-demo-emailservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: emailservice
+      component: otel-demo-emailservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: emailservice
+        app: emailservice
+        component: otel-demo-emailservice
+    spec:
+      containers:
+      - name: emailservice
+        image:  otel/demo:v0.2.0-alpha-emailservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=emailservice,deployment.environment=staging"
+        - name: PORT
+          value: "8080"
+        - name: APP_ENV
+          value: staging
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: emailservice
+  labels:
+    app: emailservice
+    component: otel-demo-emailservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: emailservice
+    component: otel-demo-emailservice
+---

--- a/k8s_local/featureflagservice.yaml
+++ b/k8s_local/featureflagservice.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/featureflagservice.yaml
+++ b/k8s_local/featureflagservice.yaml
@@ -1,0 +1,85 @@
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: featureflagservice
+  labels:
+    app: featureflagservice
+    component: otel-demo-featureflagservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureflagservice
+      component: otel-demo-featureflagservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: featureflagservice
+        app: featureflagservice
+        component: otel-demo-featureflagservice
+    spec:
+      containers:
+      - name: featureflagservice
+        image:  otel/demo:v0.2.0-alpha-featureflagservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=featureflagservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: PORT
+          value: "50052"
+        - name: GRPC_PORT
+          value: "50053"
+        - name: DATABASE_URL
+          value: "ecto://ffs:ffs@postgres:5432/ffs"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: featureflagservice
+  labels:
+    app: featureflagservice
+    component: otel-demo-featureflagservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 50052
+      protocol: TCP
+      name: http
+    - port: 50053
+      name: grpc
+  selector:
+    app: featureflagservice
+    component: otel-demo-featureflagservice
+---

--- a/k8s_local/frontend.yaml
+++ b/k8s_local/frontend.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/frontend.yaml
+++ b/k8s_local/frontend.yaml
@@ -1,0 +1,114 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+    component: otel-demo-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+      component: otel-demo-frontend
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: frontend
+        app: frontend
+        component: otel-demo-frontend
+    spec:
+      containers:
+      - name: frontend
+        image:  otel/demo:v0.2.0-alpha-frontend
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=frontend,,deployment.environment=staging"
+        - name: AD_SERVICE_PORT
+          value: "9555"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:$(AD_SERVICE_PORT)"
+        - name: CART_SERVICE_PORT
+          value: "7070"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:$(CART_SERVICE_PORT)"
+        - name: CHECKOUT_SERVICE_PORT
+          value: "5050"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:$(CHECKOUT_SERVICE_PORT)"
+        - name: CURRENCY_SERVICE_PORT
+          value: "7000"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:$(CURRENCY_SERVICE_PORT)"
+        - name: EMAIL_SERVICE_PORT
+          value: "8080"
+        - name: EMAIL_SERVICE_ADDR
+          value: "http://emailservice:$(EMAIL_SERVICE_PORT)"
+        - name: FRONTEND_PORT
+          value: "8080"
+        - name: FRONTEND_ADDR
+          value: ":$(FRONTEND_PORT)"
+        - name: PAYMENT_SERVICE_PORT
+          value: "50051"
+        - name: PAYMENT_SERVICE_ADDR
+          value: "paymentservice:$(PAYMENT_SERVICE_PORT)"
+        - name: PRODUCT_CATALOG_SERVICE_PORT
+          value: "3550"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:$(PRODUCT_CATALOG_SERVICE_PORT)"
+        - name: RECOMMENDATION_SERVICE_PORT
+          value: "9001"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:$(RECOMMENDATION_SERVICE_PORT)"
+        - name: SHIPPING_SERVICE_PORT
+          value: "50051"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:$(SHIPPING_SERVICE_PORT)"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+    component: otel-demo-frontend
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: frontend
+    component: otel-demo-frontend
+---

--- a/k8s_local/grafana.yaml
+++ b/k8s_local/grafana.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-config
+  labels:
+    team: team-opentelemetry
+    service: grafana
+    app: grafana
+    component: grafana-config
+data:
+  grafana.ini: |
+    [paths]
+    provisioning = /etc/grafana/provisioning
+    [auth]
+    disable_login_form = true
+    [auth.anonymous]
+    enabled  = true
+    org_name = Main Org.
+    org_role = Admin
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-provisioning
+  labels:
+    team: team-opentelemetry
+    service: grafana
+    app: grafana
+    component: grafana-provisioning
+data:
+  default.yaml: |
+    apiVersion: 1
+
+    datasources:
+      - name: webstore
+        type: prometheus
+        url: http://prometheus:9090
+        editable: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+    component: otel-demo-grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      component: otel-demo-grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+        component: otel-demo-grafana
+        team: team-opentelemetry
+        service: grafana
+    spec:
+      containers:
+      - name: grafana
+        image:  grafana/grafana:9.0.1
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 100m
+          requests:
+            memory: 200Mi
+            cpu: 100m
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/grafana
+        - name: provisioning
+          mountPath: /etc/grafana/provisioning/datasources
+      volumes:
+        - name: config
+          configMap:
+            name: grafana-config
+        - name: provisioning
+          configMap:
+            name: grafana-provisioning
+          
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app: grafana
+    component: otel-demo-grafana
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: grafana
+    component: otel-demo-grafana
+---

--- a/k8s_local/jaeger.yaml
+++ b/k8s_local/jaeger.yaml
@@ -1,0 +1,86 @@
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+  labels:
+    app: jaeger
+    component: otel-demo-jaeger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jaeger
+      component: otel-demo-jaeger
+  template:
+    metadata:
+      labels:
+        app: jaeger
+        component: otel-demo-jaeger
+        team: team-opentelemetry
+        service: jaeger
+    spec:
+      containers:
+      - name: jaeger
+        image:  jaegertracing/all-in-one
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: COLLECTOR_ZIPKIN_HOST_PORT
+          value: ":9411"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  labels:
+    app: jaeger
+    component: otel-demo-jaeger
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 5775
+      protocol: TCP
+      name: port1
+    - port: 5778
+      protocol: TCP
+      name: port2
+    - port: 6831
+      protocol: TCP
+      name: port3
+    - port: 6832
+      protocol: TCP
+      name: port4
+    - port: 9411
+      protocol: TCP
+      name: port5
+    - port: 16686
+      protocol: TCP
+      name: port6
+    - port: 14250
+      protocol: TCP
+      name: port7
+    - port: 14268
+      protocol: TCP
+      name: port8
+    - port: 14269
+      protocol: TCP
+      name: port9
+  selector:
+    app: jaeger
+    component: otel-demo-jaeger
+---

--- a/k8s_local/jaeger.yaml
+++ b/k8s_local/jaeger.yaml
@@ -28,11 +28,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 200Mi
-            cpu: 200m
+            memory: 500Mi
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: HOST_IP
           valueFrom:

--- a/k8s_local/loadgenerator.yaml
+++ b/k8s_local/loadgenerator.yaml
@@ -29,10 +29,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/loadgenerator.yaml
+++ b/k8s_local/loadgenerator.yaml
@@ -1,0 +1,71 @@
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+  labels:
+    app: loadgenerator
+    component: otel-demo-loadgenerator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loadgenerator
+      component: otel-demo-loadgenerator
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: loadgenerator
+        app: loadgenerator
+        component: otel-demo-loadgenerator
+    spec:
+      containers:
+      - name: loadgenerator
+        image:  otel/demo:v0.2.0-alpha-loadgenerator
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: DD_DATACENTER
+          value: us1.staging.dog
+        - name: DD_SITE
+          value: datad0g.com
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=loadgenerator,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: FRONTEND_PORT
+          value: "8080"
+        - name: FRONTEND_ADDR
+          value: "frontend:$(FRONTEND_PORT)"
+        - name: USERS
+          value: "10"
+        - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+          value: python
+
+---

--- a/k8s_local/otel-agent-daemonset.yaml
+++ b/k8s_local/otel-agent-daemonset.yaml
@@ -113,7 +113,7 @@ data:
           insecure: true
       logging:
       prometheus:
-        endpoint: "prometheus:9464"
+        endpoint: ":9464"
 
     processors:
       resourcedetection:
@@ -171,7 +171,7 @@ spec:
             cpu: 1
             memory: 2Gi
           requests:
-            cpu: 200m
+            cpu: 100m
             memory: 400Mi
         env:
         - name: HOST_IP
@@ -216,6 +216,8 @@ spec:
       name: grpc
     - port: 8888
       name: http-metrics
+    - port: 9464
+      name: prometheus
   selector:
     app: otel-agent
     component: otel-demo-otel-agent

--- a/k8s_local/otel-collector-daemonset.yaml
+++ b/k8s_local/otel-collector-daemonset.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-collector-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - namespaces/status
+  - nodes
+  - nodes/spec
+  - pods
+  - pods/status
+  - replicationcontrollers
+  - replicationcontrollers/status
+  - resourcequotas
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+  verbs:
+    - get
+    - list
+    - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: otel-collector
+subjects:
+- kind: ServiceAccount
+  name: otel-collector
+  namespace: otel
+roleRef:
+  kind: ClusterRole
+  name: otel-collector-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-agent-config
+  labels:
+    team: team-opentelemetry
+    service: otel-agent
+    app: otel-agent
+    component: otel-agent-config
+data:
+  otel-agent-config.yaml: |
+    receivers:
+      k8s_cluster:
+        collection_interval: 10s
+      hostmetrics:
+        scrapers:
+          cpu:
+          disk:
+          filesystem:
+          load:
+          memory:
+          network:
+          processes:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    exporters:
+      jaeger:
+        endpoint: "jaeger:14250"
+        tls:
+          insecure: true
+      logging:
+      prometheus:
+        endpoint: "prometheus:9464"
+
+    processors:
+      resourcedetection:
+        # ensures host.name and other important resource tags 
+        # get picked up
+        detectors: [system, env ]
+        timeout: 5s
+        override: false
+      # adds various tags related to k8s
+      k8sattributes:
+      batch:
+        timeout: 10s
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp, k8s_cluster,hostmetrics]
+          processors: [batch, k8sattributes, resourcedetection]
+          exporters: [logging,prometheus ]
+
+        traces:
+          receivers: [otlp]
+          processors: [resourcedetection, k8sattributes, batch]
+          exporters: [ logging, jaeger ]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-agent
+  labels:
+    app: otel-agent
+    component: otel-demo-otel-agent
+spec:
+  selector:
+    matchLabels:
+      app: otel-agent
+      component: otel-demo-otel-agent
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: otel-agent
+        app: otel-agent
+        component: otel-demo-otel-agent
+    spec:
+      serviceAccountName: otel-collector
+      containers:
+      - name: collector
+        command:
+          - "/otelcol-contrib"
+          - "--config=/etc/config/otel-agent-config.yaml"
+        image: otel/opentelemetry-collector-contrib:0.55.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.pod.ip=$(POD_IP)"
+        ports:
+        - containerPort: 4318 # default port for OpenTelemetry HTTP receiver.
+          hostPort: 4318
+        - containerPort: 4317 # default port for OpenTelemetry gRPC receiver.
+          hostPort: 4317
+        - containerPort: 8888  # Default endpoint for querying metrics.
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+      volumes:
+        - name: config
+          configMap:
+            name: otel-agent-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-agent
+  labels:
+    app: otel-agent
+    component: otel-demo-otel-agent
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 4318
+      protocol: TCP
+      name: http
+    - port: 4317
+      name: grpc
+    - port: 8888
+      name: http-metrics
+  selector:
+    app: otel-agent
+    component: otel-demo-otel-agent
+---

--- a/k8s_local/paymentservice.yaml
+++ b/k8s_local/paymentservice.yaml
@@ -1,0 +1,79 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+    component: otel-demo-paymentservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+      component: otel-demo-paymentservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: paymentservice
+        app: paymentservice
+        component: otel-demo-paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image:  otel/demo:v0.2.0-alpha-paymentservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=paymentservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: PAYMENT_SERVICE_PORT
+          value: "50051"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+    component: otel-demo-paymentservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 50051
+      protocol: TCP
+      name: http
+  selector:
+    app: paymentservice
+    component: otel-demo-paymentservice
+---

--- a/k8s_local/paymentservice.yaml
+++ b/k8s_local/paymentservice.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/port_forward.sh
+++ b/k8s_local/port_forward.sh
@@ -1,0 +1,15 @@
+#
+quitjobs() {
+  echo ""
+  pkill -P $$
+  echo "Killed all running jobs".
+  scriptCancelled="true"
+  trap - INT
+  exit
+}
+trap quitjobs INT
+
+kubectl port-forward svc/frontend 8080:8080 &
+kubectl port-forward svc/grafana 3000:3000 &
+kubectl port-forward svc/prometheus 9090:9090 &
+kubectl port-forward svc/jaeger 16686:16686

--- a/k8s_local/postgres.yaml
+++ b/k8s_local/postgres.yaml
@@ -1,0 +1,66 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    component: otel-demo-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+      component: otel-demo-postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        component: otel-demo-postgres
+        team: team-opentelemetry
+        service: postgres
+    spec:
+      containers:
+      - name: postgres
+        image:  cimg/postgres:14.2
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          
+        - name: POSTGRES_USER
+          value: ffs
+        - name: POSTGRES_DB
+          value: ffs
+        - name: POSTGRES_PASSWORD
+          value: ffs
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+    component: otel-demo-postgres
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 5432
+      protocol: TCP
+      name: http
+  selector:
+    app: postgres
+    component: otel-demo-postgres
+---

--- a/k8s_local/postgres.yaml
+++ b/k8s_local/postgres.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: HOST_IP
           valueFrom:

--- a/k8s_local/productcatalogservice.yaml
+++ b/k8s_local/productcatalogservice.yaml
@@ -27,10 +27,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/productcatalogservice.yaml
+++ b/k8s_local/productcatalogservice.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: productcatalogservice
+  labels:
+    app: productcatalogservice
+    component: otel-demo-productcatalogservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: productcatalogservice
+      component: otel-demo-productcatalogservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: productcatalogservice
+        app: productcatalogservice
+        component: otel-demo-productcatalogservice
+    spec:
+      containers:
+      - name: productcatalogservice
+        image:  otel/demo:v0.2.0-alpha-productcatalogservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=productcatalogservice,deployment.environment=staging"
+        - name: PRODUCT_CATALOG_SERVICE_PORT
+          value: "3550"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: productcatalogservice
+  labels:
+    app: productcatalogservice
+    component: otel-demo-productcatalogservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: productcatalogservice
+    component: otel-demo-productcatalogservice
+---

--- a/k8s_local/prometheus.yaml
+++ b/k8s_local/prometheus.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  labels:
+    team: team-opentelemetry
+    service: prometheus
+    app: prometheus
+    component: prometheus-config
+data:
+  prometheus-config.yaml: |
+    global:
+      evaluation_interval: 30s
+      scrape_interval: 5s
+    scrape_configs:
+    - job_name: otel
+      static_configs:
+      - targets:
+        - ':9464'
+    - job_name: otel-collector
+      static_configs:
+      - targets:
+        - ':8888'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+    component: otel-demo-prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      component: otel-demo-prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        component: otel-demo-prometheus
+        team: team-opentelemetry
+        service: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image:  quay.io/prometheus/prometheus:v2.34.0
+        imagePullPolicy: IfNotPresent
+        command:
+          - /bin/prometheus
+          - --web.console.templates=/etc/prometheus/consoles
+          - --web.console.libraries=/etc/prometheus/console_libraries
+          - --storage.tsdb.retention.time=1h
+          - --config.file=/etc/config/prometheus-config.yaml
+          - --storage.tsdb.path=/prometheus
+          - --web.enable-lifecycle
+          - --web.route-prefix=/
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+          
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  labels:
+    app: prometheus
+    component: otel-demo-prometheus
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 9464
+      protocol: TCP
+      name: http
+  selector:
+    app: prometheus
+    component: otel-demo-prometheus
+---

--- a/k8s_local/prometheus.yaml
+++ b/k8s_local/prometheus.yaml
@@ -17,11 +17,11 @@ data:
     - job_name: otel
       static_configs:
       - targets:
-        - ':9464'
+        - 'otel-agent:9464'
     - job_name: otel-collector
       static_configs:
       - targets:
-        - ':8888'
+        - '0.0.0.0:8888'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -60,10 +60,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: HOST_IP
           valueFrom:
@@ -93,6 +93,9 @@ spec:
     - port: 9464
       protocol: TCP
       name: http
+    - port: 9090
+      protocol: TCP
+      name: ui
   selector:
     app: prometheus
     component: otel-demo-prometheus

--- a/k8s_local/recommendationservice.yaml
+++ b/k8s_local/recommendationservice.yaml
@@ -1,0 +1,88 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendationservice
+  labels:
+    app: recommendationservice
+    component: otel-demo-recommendationservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: recommendationservice
+      component: otel-demo-recommendationservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: recommendationservice
+        app: recommendationservice
+        component: otel-demo-recommendationservice
+    spec:
+      containers:
+      - name: recommendationservice
+        image:  otel/demo:v0.2.0-alpha-recommendationservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=recommendationservice,deployment.environment=staging"
+        - name: APP_ENV
+          value: staging
+        - name: RECOMMENDATION_SERVICE_PORT
+          value: "9001"
+        - name: OTEL_PYTHON_LOG_CORRELATION
+          value: "true"
+        - name: PRODUCT_CATALOG_SERVICE_PORT
+          value: "3550"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:$(PRODUCT_CATALOG_SERVICE_PORT)"
+
+
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendationservice
+  labels:
+    app: recommendationservice
+    component: otel-demo-recommendationservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 9555
+      protocol: TCP
+      name: http
+  selector:
+    app: recommendationservice
+    component: otel-demo-recommendationservice
+---
+

--- a/k8s_local/recommendationservice.yaml
+++ b/k8s_local/recommendationservice.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:

--- a/k8s_local/redis.yaml
+++ b/k8s_local/redis.yaml
@@ -1,0 +1,60 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+    component: otel-demo-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      component: otel-demo-redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        component: otel-demo-redis
+        team: team-opentelemetry
+        service: redis
+    spec:
+      containers:
+      - name: redis
+        image:  redis:alpine
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+    component: otel-demo-redis
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 6379
+      protocol: TCP
+      name: http
+  selector:
+    app: redis
+    component: otel-demo-redis
+---

--- a/k8s_local/redis.yaml
+++ b/k8s_local/redis.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: HOST_IP
           valueFrom:

--- a/k8s_local/shippingservice.yaml
+++ b/k8s_local/shippingservice.yaml
@@ -1,0 +1,77 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shippingservice
+  labels:
+    app: shippingservice
+    component: otel-demo-shippingservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shippingservice
+      component: otel-demo-shippingservice
+  template:
+    metadata:
+      labels:
+        team: team-opentelemetry
+        service: shippingservice
+        app: shippingservice
+        component: otel-demo-shippingservice
+    spec:
+      containers:
+      - name: shippingservice
+        image:  otel/demo:v0.2.0-alpha-shippingservice
+        imagePullPolicy: Always
+        resources:
+          limits:
+            memory: 200Mi
+            cpu: 200m
+          requests:
+            memory: 200Mi
+            cpu: 200m
+        env:
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+               apiVersion: v1
+               fieldPath: status.podIP
+        - name: OTEL_RESOURCE
+          value: k8s.pod.ip=$(MY_POD_IP)
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+          
+        - name: OTEL_AGENT_ENDPOINT
+          value: "$(HOST_IP)"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4318"
+        - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+          value: "http://$(OTEL_AGENT_ENDPOINT):4317"
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "service.name=shippingservice,deployment.environment=staging"
+        - name: SHIPPING_SERVICE_PORT
+          value: "50051"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shippingservice
+  labels:
+    app: shippingservice
+    component: otel-demo-shippingservice
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 50051
+      protocol: TCP
+      name: http
+  selector:
+    app: shippingservice
+    component: otel-demo-shippingservice
+---

--- a/k8s_local/shippingservice.yaml
+++ b/k8s_local/shippingservice.yaml
@@ -28,10 +28,10 @@ spec:
         resources:
           limits:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
           requests:
             memory: 200Mi
-            cpu: 200m
+            cpu: 100m
         env:
         - name: MY_POD_IP
           valueFrom:


### PR DESCRIPTION
Fixes a part of #153  
Adds kubernetes files to test webstore in a `k8s` cluster. 
## Changes

1. Adds a new directory `k8s_local` with the setup necessary to run the demo webstore on a k8s cluster. 
2. Adds changes to `Makefile` to make easy to setup the services in `k8s`

Cons of the approach:
1. We now a different config files for running services via `docker-compose` and `k8s` but that is inevitable as some of config are different are different in two environments. 
 
