### PR TITLE
Add commands to install dependencies for arm64

### DIFF
--- a/src/paymentservice/Dockerfile
+++ b/src/paymentservice/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /usr/src/app/
 
 COPY ./src/paymentservice/package*.json ./
 
-RUN npm ci --omit=dev
+RUN apk add --no-cache python3 make g++ && npm ci --omit=dev
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #213 .

## Changes

- (payment service) Add commands to install dependencies (python, make, g++) for arm64.