### PR TITLE
[paymentservice] Add missing dependencies

### DIFF
--- a/src/paymentservice/package-lock.json
+++ b/src/paymentservice/package-lock.json
@@ -10,10 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@grpc/grpc-js": "1.6.7",
-        "@opentelemetry/auto-instrumentations-node": "0.31.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.29.2",
-        "@opentelemetry/sdk-node": "0.29.2",
-        "grpc-health-check": "1.8.0",
+        "@grpc/proto-loader": "^0.7.0",
+        "@opentelemetry/api": "^1.1.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.30.0",
+        "@opentelemetry/sdk-node": "^0.30.0",
+        "grpc-health-check": "^1.3.1-pre1",
         "pino": "8.1.0",
         "simple-card-validator": "1.1.0",
         "uuid": "8.3.2"
@@ -44,7 +46,7 @@
         "node": "^8.13.0 || >=10.10.0"
       }
     },
-    "node_modules/@grpc/proto-loader": {
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
       "version": "0.6.13",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
       "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
@@ -53,6 +55,49 @@
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
         "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.0.tgz",
+      "integrity": "sha512-SGPZtVmqOvNfPFOA/nNPn+0Weqa5wubBgQ56+JgTbeLY2VezwtMjwPPFzh0kvQccwWT3a2TXT0ZGK/pJoOTk1A==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -228,11 +273,11 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.3.1.tgz",
-      "integrity": "sha512-NKUY3SGiEEIOD3EpB8erpEF4K1iyXkWald1vJMaa973+EPTASNSXvzf8hZa7nhnUVxYbxtTJqbSRsZFfbZpw4g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.4.0.tgz",
+      "integrity": "sha512-yXpe1qCK3CevzWN3VmLlEOcipNdSV6al204lWMDoBI4eCy3rWZZEAGlwRvIiEy3uPrHClh6BQ5Z0q1+LEB/y8g==",
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
@@ -253,23 +298,88 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.29.2.tgz",
-      "integrity": "sha512-p900M4RJwtGmNgTLxQCv2S3XIJIXd+QAtBtJ8GfCvm94wO/x91RZbqYkaLxfYVDzMHe+cxW3q7p9ahfHPx35hQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.30.0.tgz",
+      "integrity": "sha512-Eu6brMmg7agKXHeUYB9wNTF5qdFgaE1jg4vJb2q17rz3A/IsSraZ8i3CnjE37ocDeXLA4cKt3llHx25zn4f1zg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.9",
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.29.2",
-        "@opentelemetry/otlp-transformer": "0.29.2",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.30.0",
+        "@opentelemetry/otlp-transformer": "0.30.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@grpc/proto-loader": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -810,52 +920,172 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
-      "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.30.0.tgz",
+      "integrity": "sha512-+dJnj2MSd3tsk+ooEw+0bF+dJs/NjGEVnCB3/FYxnUFaW9cCBbQQyt6X3YQYtYrEx4EEiTlwrW8pUpB1tsup7A==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1"
+        "@opentelemetry/core": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.29.2.tgz",
-      "integrity": "sha512-iNj1E7downme1PePb8itxg0/NF/l7SX3rGuDsR2+rCwwbd0NfmUN/6xwF1YupP6Z1/ThG0YE37eK/F1NZOt6mQ==",
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.5.9",
-        "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/otlp-exporter-base": "0.29.2"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.29.2.tgz",
-      "integrity": "sha512-Y6dJj+rhRGynxhLlgEJkdkXuLHdFG8igcSBv6oy3m3GHSSvZkyNV34dVjtZJ586mUXsbFuAf6uqjzteobewO1g==",
-      "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-metrics-base": "0.29.2",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
-      },
-      "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.30.0.tgz",
+      "integrity": "sha512-86fuhZ7Z2un3L5Kd7jbH1oEn92v9DD92teErnYRXqYB/qyO61OLxaY6WxH9KOjmbs5CgCdLQ5bvED3wWDe3r7w==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.5.9",
+        "@grpc/proto-loader": "^0.6.9",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/otlp-exporter-base": "0.30.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@grpc/proto-loader": {
+      "version": "0.6.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.3",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/protobufjs": {
+      "version": "6.11.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.30.0.tgz",
+      "integrity": "sha512-BTLXyBPBlCQCG4tXYZjlso4pT+gGpnTjzkFYTPYs52fO5DMWvYHlV8ST/raOIqX7wsamiH2zeqJ9W91017MtdA==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-metrics-base": "0.30.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+      "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
@@ -884,168 +1114,311 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.3.1.tgz",
-      "integrity": "sha512-tEAtHsRr6l3glsmKaJiJ/7HDw/isPv+f8OBsWJqkSlfLicKes8T/1D7nEDC6jPACiEbD3f6oK1KQSpMijC9/UQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.4.0.tgz",
+      "integrity": "sha512-KKFjvU2qrOEoK2S9FfSkE11u3AVxCniJOH7av6pmbFwkv1YD6uHNqvjvY4Xe6VwFOyKuTYS69VydO9OjJ5gvVA==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1"
+        "@opentelemetry/core": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.3.1.tgz",
-      "integrity": "sha512-H6swQcjZ8aMCS5caZaEBaadfn205IqLlB3ZyY+tCWDf5YPwJgPpjw3qgYgWulHVSEzK7VQTle/mZG7u9MAe6Pw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.4.0.tgz",
+      "integrity": "sha512-LvSzgt9RIGYiMP9E45ifT5WtALsDyY74y/1Ol0DK4xmJt8Sku7YastjCZaxpsvLGA4CGAtth0ozic88AvJrmgw==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1"
+        "@opentelemetry/core": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.1.1.tgz",
-      "integrity": "sha512-HPD8WMUJSVph+ImJVlP5OfJHCOXmfd/nhkdDos/5uy8Y0usURsL4OQLYrNGiGpdtbPAz+MC0CfQoYv+GXoaO6w==",
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/resource-detector-gcp": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.27.1.tgz",
-      "integrity": "sha512-+A6XJ8qGFq2VDxTuDC8+J4YatVJpm6uEbUajkWWCHk2nJoIGec5OYETJLprifqvh+5yXVmVCEWjdwlFWkXM5Ww==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "gcp-metadata": "^4.1.4",
-        "semver": "7.3.5"
-      },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/resource-detector-gcp/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
-      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics-base": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.30.0.tgz",
+      "integrity": "sha512-3BDg1MYDInDyGvy+bSH8OuCX5nsue7omH6Y2eidCGTTDYRPxDmq9tsRJxnTUepoMAvWX+1sTwZ4JqTFmc1z8Mw==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
         "lodash.merge": "4.6.2"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.29.2.tgz",
-      "integrity": "sha512-R/RyNXgEWLsIrFwQD9f4taDHbKVEDZcJFcOTJmbWSjxjj1ZkRCYePjGfg6beuAdcd1m1YygN02+Ko8JrV/Ekjg==",
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+      "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
       "dependencies": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/instrumentation": "0.29.2",
-        "@opentelemetry/resource-detector-aws": "~1.1.0",
-        "@opentelemetry/resource-detector-gcp": "~0.27.0",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-metrics-base": "0.29.2",
-        "@opentelemetry/sdk-trace-base": "1.3.1",
-        "@opentelemetry/sdk-trace-node": "1.3.1"
+        "@opentelemetry/api": "^1.0.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.30.0.tgz",
+      "integrity": "sha512-Zq6tpXSVV16CpDbFbAiH0YNWe72oq7Y6RpbcofJ0a2q7ywLWdZpIgh/YDIjkmHQegqCYlZQwMv4Ru+PydFyjzQ==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/instrumentation": "0.30.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-metrics-base": "0.30.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
+        "@opentelemetry/sdk-trace-node": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/api-metrics": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+      "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.30.0.tgz",
+      "integrity": "sha512-9bjRx81B6wbJ7CGWc/WCUfcb0QIG5UIcjnPTzwYIURjYPd8d0ZzRlrnqEdQG62jn4lSPEvnNqTlyC7qXtn9nAA==",
+      "dependencies": {
+        "@opentelemetry/api-metrics": "0.30.0",
+        "require-in-the-middle": "^5.0.3",
+        "semver": "^7.3.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
-      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
       "dependencies": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.3.1.tgz",
-      "integrity": "sha512-4sn/pYhaVaEI8WY0arivM77858IM5BjUKvymjJ+HmRNWBocCJKCCCY4P9cL8w8iCGGmst5yxecMyvM7OOFBnmg==",
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.3.1",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/propagator-b3": "1.3.1",
-        "@opentelemetry/propagator-jaeger": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1",
-        "semver": "^7.3.5"
+        "@opentelemetry/semantic-conventions": "1.4.0"
       },
       "engines": {
-        "node": ">=8.12.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
+      "integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.4.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/propagator-b3": "1.4.0",
+        "@opentelemetry/propagator-jaeger": "1.4.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+      "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -1575,14 +1948,6 @@
         }
       ]
     },
-    "node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1814,11 +2179,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -1984,33 +2344,6 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
-      "dependencies": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -2282,17 +2615,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/joi": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
@@ -2303,14 +2625,6 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
-      }
-    },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -2700,9 +3014,9 @@
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
+      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2717,12 +3031,16 @@
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -3200,17 +3518,51 @@
       "requires": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.6.13",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+          "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+          "requires": {
+            "@types/long": "^4.0.1",
+            "lodash.camelcase": "^4.3.0",
+            "long": "^4.0.0",
+            "protobufjs": "^6.11.3",
+            "yargs": "^16.2.0"
+          }
+        },
+        "protobufjs": {
+          "version": "6.11.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-      "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.0.tgz",
+      "integrity": "sha512-SGPZtVmqOvNfPFOA/nNPn+0Weqa5wubBgQ56+JgTbeLY2VezwtMjwPPFzh0kvQccwWT3a2TXT0ZGK/pJoOTk1A==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^6.11.3",
+        "protobufjs": "^7.0.0",
         "yargs": "^16.2.0"
       }
     },
@@ -3359,9 +3711,9 @@
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.3.1.tgz",
-      "integrity": "sha512-NKUY3SGiEEIOD3EpB8erpEF4K1iyXkWald1vJMaa973+EPTASNSXvzf8hZa7nhnUVxYbxtTJqbSRsZFfbZpw4g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.4.0.tgz",
+      "integrity": "sha512-yXpe1qCK3CevzWN3VmLlEOcipNdSV6al204lWMDoBI4eCy3rWZZEAGlwRvIiEy3uPrHClh6BQ5Z0q1+LEB/y8g==",
       "requires": {}
     },
     "@opentelemetry/core": {
@@ -3373,17 +3725,64 @@
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.29.2.tgz",
-      "integrity": "sha512-p900M4RJwtGmNgTLxQCv2S3XIJIXd+QAtBtJ8GfCvm94wO/x91RZbqYkaLxfYVDzMHe+cxW3q7p9ahfHPx35hQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.30.0.tgz",
+      "integrity": "sha512-Eu6brMmg7agKXHeUYB9wNTF5qdFgaE1jg4vJb2q17rz3A/IsSraZ8i3CnjE37ocDeXLA4cKt3llHx25zn4f1zg==",
       "requires": {
         "@grpc/grpc-js": "^1.5.9",
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.29.2",
-        "@opentelemetry/otlp-transformer": "0.29.2",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.30.0",
+        "@opentelemetry/otlp-transformer": "0.30.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.6.13",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+          "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+          "requires": {
+            "@types/long": "^4.0.1",
+            "lodash.camelcase": "^4.3.0",
+            "long": "^4.0.0",
+            "protobufjs": "^6.11.3",
+            "yargs": "^16.2.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        },
+        "protobufjs": {
+          "version": "6.11.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation": {
@@ -3746,34 +4145,119 @@
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.29.2.tgz",
-      "integrity": "sha512-tTK+v2ER9Rv7YQXLrCvZpPdNdvZx8TGdZtlK7TKnzpyMRBIf7lqV1Jl0VaHFml+cgVJcGtow/ER6k5uJ5W4kUQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.30.0.tgz",
+      "integrity": "sha512-+dJnj2MSd3tsk+ooEw+0bF+dJs/NjGEVnCB3/FYxnUFaW9cCBbQQyt6X3YQYtYrEx4EEiTlwrW8pUpB1tsup7A==",
       "requires": {
-        "@opentelemetry/core": "1.3.1"
+        "@opentelemetry/core": "1.4.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.29.2.tgz",
-      "integrity": "sha512-iNj1E7downme1PePb8itxg0/NF/l7SX3rGuDsR2+rCwwbd0NfmUN/6xwF1YupP6Z1/ThG0YE37eK/F1NZOt6mQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.30.0.tgz",
+      "integrity": "sha512-86fuhZ7Z2un3L5Kd7jbH1oEn92v9DD92teErnYRXqYB/qyO61OLxaY6WxH9KOjmbs5CgCdLQ5bvED3wWDe3r7w==",
       "requires": {
         "@grpc/grpc-js": "^1.5.9",
         "@grpc/proto-loader": "^0.6.9",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/otlp-exporter-base": "0.29.2"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/otlp-exporter-base": "0.30.0"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.6.13",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
+          "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
+          "requires": {
+            "@types/long": "^4.0.1",
+            "lodash.camelcase": "^4.3.0",
+            "long": "^4.0.0",
+            "protobufjs": "^6.11.3",
+            "yargs": "^16.2.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        },
+        "protobufjs": {
+          "version": "6.11.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
+          "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.29.2.tgz",
-      "integrity": "sha512-Y6dJj+rhRGynxhLlgEJkdkXuLHdFG8igcSBv6oy3m3GHSSvZkyNV34dVjtZJ586mUXsbFuAf6uqjzteobewO1g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.30.0.tgz",
+      "integrity": "sha512-BTLXyBPBlCQCG4tXYZjlso4pT+gGpnTjzkFYTPYs52fO5DMWvYHlV8ST/raOIqX7wsamiH2zeqJ9W91017MtdA==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-metrics-base": "0.29.2",
-        "@opentelemetry/sdk-trace-base": "1.3.1"
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-metrics-base": "0.30.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0"
+      },
+      "dependencies": {
+        "@opentelemetry/api-metrics": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+          "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/propagation-utils": {
@@ -3791,110 +4275,208 @@
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.3.1.tgz",
-      "integrity": "sha512-tEAtHsRr6l3glsmKaJiJ/7HDw/isPv+f8OBsWJqkSlfLicKes8T/1D7nEDC6jPACiEbD3f6oK1KQSpMijC9/UQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.4.0.tgz",
+      "integrity": "sha512-KKFjvU2qrOEoK2S9FfSkE11u3AVxCniJOH7av6pmbFwkv1YD6uHNqvjvY4Xe6VwFOyKuTYS69VydO9OjJ5gvVA==",
       "requires": {
-        "@opentelemetry/core": "1.3.1"
+        "@opentelemetry/core": "1.4.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.3.1.tgz",
-      "integrity": "sha512-H6swQcjZ8aMCS5caZaEBaadfn205IqLlB3ZyY+tCWDf5YPwJgPpjw3qgYgWulHVSEzK7VQTle/mZG7u9MAe6Pw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.4.0.tgz",
+      "integrity": "sha512-LvSzgt9RIGYiMP9E45ifT5WtALsDyY74y/1Ol0DK4xmJt8Sku7YastjCZaxpsvLGA4CGAtth0ozic88AvJrmgw==",
       "requires": {
-        "@opentelemetry/core": "1.3.1"
-      }
-    },
-    "@opentelemetry/resource-detector-aws": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.1.1.tgz",
-      "integrity": "sha512-HPD8WMUJSVph+ImJVlP5OfJHCOXmfd/nhkdDos/5uy8Y0usURsL4OQLYrNGiGpdtbPAz+MC0CfQoYv+GXoaO6w==",
-      "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/resource-detector-gcp": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-gcp/-/resource-detector-gcp-0.27.1.tgz",
-      "integrity": "sha512-+A6XJ8qGFq2VDxTuDC8+J4YatVJpm6uEbUajkWWCHk2nJoIGec5OYETJLprifqvh+5yXVmVCEWjdwlFWkXM5Ww==",
-      "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "gcp-metadata": "^4.1.4",
-        "semver": "7.3.5"
+        "@opentelemetry/core": "1.4.0"
       },
       "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
           "requires": {
-            "lru-cache": "^6.0.0"
+            "@opentelemetry/semantic-conventions": "1.4.0"
           }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
         }
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.3.1.tgz",
-      "integrity": "sha512-X8bl3X0YjlsHWy0Iv0KUETtZuRUznX4yr1iScKCtfy8AoRfZFc2xxWKMDJ0TrqYwSapgeg4YwpmRzUKmmnrbeA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.4.0.tgz",
+      "integrity": "sha512-Q3pI5+pCM+Ur7YwK9GbG89UBipwJbfmuzSPAXTw964ZHFzSrz+JAgrETC9rqsUOYdUlj/V7LbRMG5bo72xE0Xw==",
       "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/sdk-metrics-base": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.29.2.tgz",
-      "integrity": "sha512-7hhhZ/6YRRgAXOUTeCsbe6SIk3wZAdAHnEwGGp7aiVH5AOyioHyHInw4EHtowlD6dbLxUWURjh6k+Geht2zbxg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics-base/-/sdk-metrics-base-0.30.0.tgz",
+      "integrity": "sha512-3BDg1MYDInDyGvy+bSH8OuCX5nsue7omH6Y2eidCGTTDYRPxDmq9tsRJxnTUepoMAvWX+1sTwZ4JqTFmc1z8Mw==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
         "lodash.merge": "4.6.2"
+      },
+      "dependencies": {
+        "@opentelemetry/api-metrics": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+          "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.29.2.tgz",
-      "integrity": "sha512-R/RyNXgEWLsIrFwQD9f4taDHbKVEDZcJFcOTJmbWSjxjj1ZkRCYePjGfg6beuAdcd1m1YygN02+Ko8JrV/Ekjg==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.30.0.tgz",
+      "integrity": "sha512-Zq6tpXSVV16CpDbFbAiH0YNWe72oq7Y6RpbcofJ0a2q7ywLWdZpIgh/YDIjkmHQegqCYlZQwMv4Ru+PydFyjzQ==",
       "requires": {
-        "@opentelemetry/api-metrics": "0.29.2",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/instrumentation": "0.29.2",
-        "@opentelemetry/resource-detector-aws": "~1.1.0",
-        "@opentelemetry/resource-detector-gcp": "~0.27.0",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/sdk-metrics-base": "0.29.2",
-        "@opentelemetry/sdk-trace-base": "1.3.1",
-        "@opentelemetry/sdk-trace-node": "1.3.1"
+        "@opentelemetry/api-metrics": "0.30.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/instrumentation": "0.30.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/sdk-metrics-base": "0.30.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
+        "@opentelemetry/sdk-trace-node": "1.4.0"
+      },
+      "dependencies": {
+        "@opentelemetry/api-metrics": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.30.0.tgz",
+          "integrity": "sha512-jSb7iiYPY+DSUKIyzfGt0a5K1QGzWY5fSWtUB8Alfi27NhQGHBeuYYC5n9MaBP/HNWw5GpEIhXGEYCF9Pf8IEg==",
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/instrumentation": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.30.0.tgz",
+          "integrity": "sha512-9bjRx81B6wbJ7CGWc/WCUfcb0QIG5UIcjnPTzwYIURjYPd8d0ZzRlrnqEdQG62jn4lSPEvnNqTlyC7qXtn9nAA==",
+          "requires": {
+            "@opentelemetry/api-metrics": "0.30.0",
+            "require-in-the-middle": "^5.0.3",
+            "semver": "^7.3.2",
+            "shimmer": "^1.2.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.3.1.tgz",
-      "integrity": "sha512-Or95QZ+9QyvAiwqj+K68z8bDDuyWF50c37w17D10GV1dWzg4Ezcectsu/GB61QcBxm3Y4br0EN5F5TpIFfFliQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.4.0.tgz",
+      "integrity": "sha512-l7EEjcOgYlKWK0hfxz4Jtkkk2DuGiqBDWmRZf7g2Is9RVneF1IgcrbYZTKGaVfBKA7lPuVtUiQ2qTv3R+dKJrw==",
       "requires": {
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/resources": "1.3.1",
-        "@opentelemetry/semantic-conventions": "1.3.1"
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/resources": "1.4.0",
+        "@opentelemetry/semantic-conventions": "1.4.0"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.3.1.tgz",
-      "integrity": "sha512-4sn/pYhaVaEI8WY0arivM77858IM5BjUKvymjJ+HmRNWBocCJKCCCY4P9cL8w8iCGGmst5yxecMyvM7OOFBnmg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.4.0.tgz",
+      "integrity": "sha512-LET70LwaE8gK3W6jpeG6C7BNbl5m8fnEgNmO0LFXHyl4yofIzficDy06zjgVtPp1urygNuYPtK/4yiactzTvZg==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.3.1",
-        "@opentelemetry/core": "1.3.1",
-        "@opentelemetry/propagator-b3": "1.3.1",
-        "@opentelemetry/propagator-jaeger": "1.3.1",
-        "@opentelemetry/sdk-trace-base": "1.3.1",
+        "@opentelemetry/context-async-hooks": "1.4.0",
+        "@opentelemetry/core": "1.4.0",
+        "@opentelemetry/propagator-b3": "1.4.0",
+        "@opentelemetry/propagator-jaeger": "1.4.0",
+        "@opentelemetry/sdk-trace-base": "1.4.0",
         "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.4.0.tgz",
+          "integrity": "sha512-faq50VFEdyC7ICAOlhSi+yYZ+peznnGjTJToha9R63i9fVopzpKrkZt7AIdXUmz2+L2OqXrcJs7EIdN/oDyr5w==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.4.0"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.4.0.tgz",
+          "integrity": "sha512-Hzl8soGpmyzja9w3kiFFcYJ7n5HNETpplY6cb67KR4QPlxp4FTTresO06qXHgHDhyIInmbLJXuwARjjpsKYGuQ=="
+        }
       }
     },
     "@opentelemetry/semantic-conventions": {
@@ -4381,11 +4963,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4552,11 +5129,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -4706,27 +5278,6 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
-      }
-    },
-    "gaxios": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
-      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "gcp-metadata": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
-      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
-      "requires": {
-        "gaxios": "^4.0.0",
-        "json-bigint": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -4927,11 +5478,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
-    "is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
-    },
     "joi": {
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.0.tgz",
@@ -4942,14 +5488,6 @@
         "@sideway/address": "^4.1.3",
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
-      }
-    },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "json-schema-traverse": {
@@ -5260,9 +5798,9 @@
       "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
+      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5276,7 +5814,14 @@
         "@protobufjs/utf8": "^1.1.0",
         "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+          "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+        }
       }
     },
     "proxy-addr": {

--- a/src/paymentservice/package.json
+++ b/src/paymentservice/package.json
@@ -12,10 +12,12 @@
   "license": "ISC",
   "dependencies": {
     "@grpc/grpc-js": "1.6.7",
-    "@opentelemetry/auto-instrumentations-node": "0.31.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.29.2",
-    "@opentelemetry/sdk-node": "0.29.2",
-    "grpc-health-check": "1.8.0",
+    "@grpc/proto-loader": "^0.7.0",
+    "@opentelemetry/api": "^1.1.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.31.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.30.0",
+    "@opentelemetry/sdk-node": "^0.30.0",
+    "grpc-health-check": "^1.8.0",
     "pino": "8.1.0",
     "simple-card-validator": "1.1.0",
     "uuid": "8.3.2"


### PR DESCRIPTION
No issue was opened, but I brought this up in slack: https://cloud-native.slack.com/archives/C03B4CWV4DA/p1657607127541249

When running the demo in WSL the `paymentservice` didn't have spans in Jaeger.

## Changes

- Updated the OTel packages version
- Added the following missing dependencies:
  - `"@grpc/proto-loader"`
  - `"@opentelemetry/api"`
