### PR TITLE
add ziqi zhao as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ For edit access, get in touch on
 - [Mikko Viitanen](https://github.com/mviitane), Dynatrace
 - [Penghan Wang](https://github.com/wph95), AppDynamics
 - [Reiley Yang](https://github.com/reyang), Microsoft
+- [Ziqi Zhao](https://github.com/fatsheep9146), Alibaba
 
 ### Thanks to all the people who have contributed
 


### PR DESCRIPTION
I'm nominating Ziqi, @fatsheep9146, to join the approvers team. He's been making consistent contributions to the demo for several months, has been completing PR reviews, added our major metric pieces, & is active over Slack / github repo issues.  

A link to his previous PRs: https://github.com/open-telemetry/opentelemetry-demo-webstore/pulls?q=is%3Apr+author%3Afatsheep9146+is%3Aclosed
